### PR TITLE
Enforce login before checkout

### DIFF
--- a/app/components/header.tsx
+++ b/app/components/header.tsx
@@ -6,9 +6,11 @@ import { Sheet, SheetContent, SheetTrigger } from "~/components/ui/sheet"
 import { Badge } from "~/components/ui/badge"
 import { Link } from "@remix-run/react"
 import { useCart } from "~/context/cart-context"
+import { useAuth } from "~/context/auth-context"
 
 export default function Header() {
   const { itemCount } = useCart()
+  const { isLoggedIn } = useAuth()
 
   return (
     <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
@@ -76,9 +78,11 @@ export default function Header() {
             <span className="sr-only">Search</span>
           </Button>
 
-          <Button variant="ghost" size="icon">
-            <User className="h-5 w-5" />
-            <span className="sr-only">Account</span>
+          <Button variant="ghost" size="icon" asChild>
+            <Link to={isLoggedIn ? "/" : "/login"}>
+              <User className="h-5 w-5" />
+              <span className="sr-only">Account</span>
+            </Link>
           </Button>
 
           <Button variant="ghost" size="icon" className="relative" asChild>

--- a/app/context/auth-context.tsx
+++ b/app/context/auth-context.tsx
@@ -1,0 +1,63 @@
+import { createContext, useContext, useEffect, useState } from "react";
+
+type User = {
+  username: string;
+};
+
+interface AuthContextType {
+  user: User | null;
+  isLoggedIn: boolean;
+  login: (user: User) => void;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<User | null>(null);
+
+  // Load user from localStorage on first render
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const stored = localStorage.getItem("user");
+      if (stored) {
+        try {
+          setUser(JSON.parse(stored));
+        } catch {
+          localStorage.removeItem("user");
+        }
+      }
+    }
+  }, []);
+
+  const login = (newUser: User) => {
+    setUser(newUser);
+    if (typeof window !== "undefined") {
+      localStorage.setItem("user", JSON.stringify(newUser));
+    }
+  };
+
+  const logout = () => {
+    setUser(null);
+    if (typeof window !== "undefined") {
+      localStorage.removeItem("user");
+    }
+  };
+
+  return (
+    <AuthContext.Provider
+      value={{ user, isLoggedIn: !!user, login, logout }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext);
+  if (context === undefined) {
+    throw new Error("useAuth must be used within an AuthProvider");
+  }
+  return context;
+}
+

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -10,6 +10,7 @@ import type { LinksFunction } from "@remix-run/node";
 
 import "./globals.css";
 import { CartProvider } from "./context/cart-context";
+import { AuthProvider } from "./context/auth-context";
 
 export const links: LinksFunction = () => [
   { rel: "preconnect", href: "https://fonts.googleapis.com" },
@@ -35,19 +36,21 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <Links />
       </head>
       <body>
-        <CartProvider>
-          {children}
-          <ScrollRestoration />
-          <script
-            // biome-ignore lint/security/noDangerouslySetInnerHtml: <explanation>
-            dangerouslySetInnerHTML={{
-              __html: `window.ENV = ${JSON.stringify({
-                env: data?.ENV,
-              })}`,
-            }}
-          />
-          <Scripts />
-        </CartProvider>
+        <AuthProvider>
+          <CartProvider>
+            {children}
+            <ScrollRestoration />
+            <script
+              // biome-ignore lint/security/noDangerouslySetInnerHtml: <explanation>
+              dangerouslySetInnerHTML={{
+                __html: `window.ENV = ${JSON.stringify({
+                  env: data?.ENV,
+                })}`,
+              }}
+            />
+            <Scripts />
+          </CartProvider>
+        </AuthProvider>
       </body>
     </html>
   );

--- a/app/routes/cart._index.tsx
+++ b/app/routes/cart._index.tsx
@@ -9,9 +9,11 @@ import { useCart } from "~/context/cart-context"
 import { ensure, jnavigate } from "~/lib/utils"
 import { Link } from "@remix-run/react"
 import Wrapper from "~/layouts/Wrapper"
+import { useAuth } from "~/context/auth-context"
 
 export default function CartPage() {
   const { items, itemCount, subtotal, updateQuantity, removeItem, clearCart } = useCart()
+  const { isLoggedIn } = useAuth()
   const [isProcessing, setIsProcessing] = useState(false)
 
   const shipping = subtotal >= 50 ? 0 : 5.99
@@ -22,8 +24,9 @@ export default function CartPage() {
     // Simulate checkout process
     setTimeout(() => {
       setIsProcessing(false)
+      const destination = isLoggedIn ? "/checkout" : "/login?redirect=/checkout"
       jnavigate({
-        path: "/checkout",
+        path: destination,
       })
     }, 1500)
   }

--- a/app/routes/checkout._index.tsx
+++ b/app/routes/checkout._index.tsx
@@ -12,6 +12,8 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "~/components/ui/tabs"
 import AddressForm, { type Address } from "~/components/features/checkout/address-form"
 import ThaiQRPayment from "~/components/features/checkout/thai-qr-payment"
 import { useCart } from "~/context/cart-context"
+import { useAuth } from "~/context/auth-context"
+import { jnavigate } from "~/lib/utils"
 import { toast } from "sonner"
 import { Link } from "@remix-run/react"
 import Wrapper from "~/layouts/Wrapper"
@@ -32,12 +34,20 @@ type Order = {
 
 export default function CheckoutPage() {
   const { items, subtotal, clearCart } = useCart()
+  const { isLoggedIn } = useAuth()
 
   const [paymentMethod, setPaymentMethod] = useState<string>("card")
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [orderComplete, setOrderComplete] = useState(false)
   const [pendingPayment, setPendingPayment] = useState(false)
   const [order, setOrder] = useState<Order | null>(null)
+
+  // Redirect to login if user is not authenticated
+  useEffect(() => {
+    if (typeof window !== "undefined" && !isLoggedIn) {
+      jnavigate({ path: "/login?redirect=/checkout" })
+    }
+  }, [isLoggedIn])
 
   // Address management
   const [addresses, setAddresses] = useState<Address[]>([])

--- a/app/routes/login._index.tsx
+++ b/app/routes/login._index.tsx
@@ -1,0 +1,57 @@
+import { useState } from "react";
+import { useSearchParams } from "@remix-run/react";
+import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+import Wrapper from "~/layouts/Wrapper";
+import { useAuth } from "~/context/auth-context";
+import { jnavigate } from "~/lib/utils";
+
+export default function LoginPage() {
+  const { login, isLoggedIn } = useAuth();
+  const [searchParams] = useSearchParams();
+  const redirect = searchParams.get("redirect") || "/";
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!isLoggedIn) {
+      login({ username });
+    }
+    jnavigate({ path: redirect });
+  };
+
+  return (
+    <Wrapper>
+      <div className="container max-w-md mx-auto px-4 py-12">
+        <h1 className="text-2xl font-bold mb-6 text-center">Login</h1>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="username">Username</Label>
+            <Input
+              id="username"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              required
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="password">Password</Label>
+            <Input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+            />
+          </div>
+          <Button type="submit" className="w-full">
+            Login
+          </Button>
+        </form>
+      </div>
+    </Wrapper>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add new `AuthProvider` context
- wrap app with `AuthProvider`
- create a simple login page
- link account icon to login page
- redirect users to login before accessing checkout

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run typecheck` *(fails: cannot find type definition file)*