### PR TITLE
Add searchable brands list

### DIFF
--- a/app/data/brand.ts
+++ b/app/data/brand.ts
@@ -1,0 +1,19 @@
+export async function getBrands() {
+  try {
+    return [
+      { brandId: 1, name: "NutriPure" },
+      { brandId: 2, name: "VitalLife" },
+      { brandId: 3, name: "BioBalance" },
+      { brandId: 4, name: "PureEssentials" },
+      { brandId: 5, name: "NatureWay" },
+      { brandId: 6, name: "OptimalHealth" },
+      { brandId: 7, name: "WellnessWorks" },
+      { brandId: 8, name: "HealthFirst" },
+      { brandId: 9, name: "FitFuel" },
+      { brandId: 10, name: "LifeStrength" },
+    ]
+  } catch (error) {
+    console.error("Error fetching brands:", error)
+    return []
+  }
+}

--- a/app/routes/brands._index.tsx
+++ b/app/routes/brands._index.tsx
@@ -1,0 +1,53 @@
+import { useLoaderData, useSearchParams } from "@remix-run/react"
+import type { LoaderFunctionArgs } from "@remix-run/node"
+import { getBrands } from "~/data/brand"
+import BrandCard from "~/components/brand-card"
+import { Input } from "~/components/ui/input"
+import Wrapper from "~/layouts/Wrapper"
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const brands = await getBrands()
+  return { brands }
+}
+
+export default function BrandsPage() {
+  const { brands } = useLoaderData<typeof loader>()
+  const [searchParams, setSearchParams] = useSearchParams()
+  const query = (searchParams.get("q") || "").toLowerCase()
+  const filtered = brands.filter((b) =>
+    b.name.toLowerCase().includes(query)
+  )
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value
+    if (value) {
+      setSearchParams({ q: value })
+    } else {
+      setSearchParams({})
+    }
+  }
+
+  return (
+    <Wrapper>
+      <div className="container mx-auto px-4 py-12">
+        <h1 className="text-3xl font-bold mb-6 text-center">Brands</h1>
+        <div className="max-w-md mx-auto mb-8">
+          <Input
+            type="search"
+            placeholder="Search brands..."
+            value={searchParams.get("q") || ""}
+            onChange={handleChange}
+          />
+        </div>
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-6">
+          {filtered.map((brand) => (
+            <BrandCard key={brand.brandId} brand={brand} />
+          ))}
+          {filtered.length === 0 && (
+            <p className="col-span-full text-center text-muted-foreground">No brands found.</p>
+          )}
+        </div>
+      </div>
+    </Wrapper>
+  )
+}


### PR DESCRIPTION
## Summary
- list available brands from mock data
- allow brand search via query string

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run typecheck` *(fails: cannot find type definitions)*