### PR TITLE
Add searchable categories page

### DIFF
--- a/app/data/category.ts
+++ b/app/data/category.ts
@@ -1,0 +1,25 @@
+export type Category = {
+  categoryId: number
+  name: string
+  productCount?: number
+}
+
+export async function getAllCategories(): Promise<Category[]> {
+  try {
+    return [
+      { categoryId: 1, name: "Vitamins", productCount: 120 },
+      { categoryId: 2, name: "Minerals", productCount: 85 },
+      { categoryId: 3, name: "Probiotics", productCount: 64 },
+      { categoryId: 4, name: "Omega-3", productCount: 42 },
+      { categoryId: 5, name: "Protein", productCount: 78 },
+      { categoryId: 6, name: "Herbs", productCount: 93 },
+      { categoryId: 7, name: "Amino Acids", productCount: 55 },
+      { categoryId: 8, name: "Antioxidants", productCount: 48 },
+      { categoryId: 9, name: "Digestive Health", productCount: 32 },
+      { categoryId: 10, name: "Immune Support", productCount: 67 },
+    ]
+  } catch (error) {
+    console.error("Error fetching categories:", error)
+    return []
+  }
+}

--- a/app/routes/categories._index.tsx
+++ b/app/routes/categories._index.tsx
@@ -1,0 +1,52 @@
+import { useLoaderData } from "@remix-run/react"
+import type { LoaderFunctionArgs } from "@remix-run/node"
+import { useMemo, useState } from "react"
+
+import CategoryCard from "~/components/category-card"
+import { Input } from "~/components/ui/input"
+import Wrapper from "~/layouts/Wrapper"
+import { getAllCategories } from "~/data/category"
+
+export async function loader({}: LoaderFunctionArgs) {
+  const categories = await getAllCategories()
+  return { categories }
+}
+
+export default function CategoriesPage() {
+  const { categories } = useLoaderData<typeof loader>()
+  const [query, setQuery] = useState("")
+
+  const filtered = useMemo(
+    () =>
+      categories.filter((c) =>
+        c.name.toLowerCase().includes(query.toLowerCase())
+      ),
+    [categories, query]
+  )
+
+  return (
+    <Wrapper>
+      <div className="container mx-auto px-4 py-12">
+        <div className="mb-6">
+          <h1 className="text-3xl font-bold mb-4">Categories</h1>
+          <Input
+            type="search"
+            placeholder="Search categories..."
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            className="max-w-md"
+          />
+        </div>
+        {filtered.length === 0 ? (
+          <p className="text-muted-foreground">No categories found.</p>
+        ) : (
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-6">
+            {filtered.map((category) => (
+              <CategoryCard key={category.categoryId} category={category} />
+            ))}
+          </div>
+        )}
+      </div>
+    </Wrapper>
+  )
+}


### PR DESCRIPTION
## Summary
- implement a new `/categories` route
- add `getAllCategories` mock data provider

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: ESLint couldn't find a config)*