### PR TITLE
Load hero banner from config API

### DIFF
--- a/app/components/hero-section.tsx
+++ b/app/components/hero-section.tsx
@@ -3,7 +3,7 @@ import { ArrowRight } from "lucide-react"
 import { Button } from "~/components/ui/button"
 import { Link } from "@remix-run/react"
 
-export default function HeroSection() {
+export default function HeroSection({ imageUrl }: { imageUrl?: string }) {
   return (
     <section className="relative">
       {/* Hero Background */}
@@ -73,10 +73,10 @@ export default function HeroSection() {
           <div className="relative">
             <div className="relative h-[400px] w-full rounded-lg overflow-hidden shadow-xl">
               <img
-                src="/placeholder.svg?height=800&width=600"
+                src={imageUrl || "/placeholder.svg?height=800&width=600"}
                 alt="Featured supplements"
                 className="object-cover"
-              // priority
+                // priority
               />
             </div>
 

--- a/app/configs/api_endpoint.ts
+++ b/app/configs/api_endpoint.ts
@@ -3,6 +3,9 @@ export const API_ENDPOINT = {
   PRODUCT_V1_DETAIL: '/api/v1/products/details/:id',
 
   // Compose Endpoint
-  COMPOSE_V1_HOME: '/api/v1/compose/home'
+  COMPOSE_V1_HOME: '/api/v1/compose/home',
+
+  // Config Endpoint
+  CONFIG_V1_GET: '/api/v1/configs/:configKey'
 
 } as const

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -10,6 +10,7 @@ import {
   getNewArrivals,
 } from "~/data/product"
 import HeroSection from "~/components/hero-section"
+import { getConfigByKey } from "~/services/configs"
 import ProductCard from "~/components/product-card"
 import CategoryCard from "~/components/category-card"
 import BrandCard from "~/components/brand-card"
@@ -25,7 +26,7 @@ export default function HomePage() {
     <Wrapper>
       <div className="flex flex-col min-h-screen">
         <main className="flex-1">
-          <HeroSection />
+          <HeroSection imageUrl={data.banner?.value.image} />
 
           {/* Categories Section */}
           <section className="py-12 px-4 md:px-6 lg:px-8 bg-gray-50">
@@ -201,9 +202,11 @@ export async function loader({ request }: LoaderFunctionArgs) {
     }
   }>('')
 
+  const banner = await getConfigByKey('banner')
+
   console.log(httpClient);
 
-  return httpClient.data;
+  return { ...httpClient.data, banner };
 }
 
 function TopCategories({ categories }: { categories: Awaited<ReturnType<typeof getTopCategories>> }) {

--- a/app/services/configs.ts
+++ b/app/services/configs.ts
@@ -1,0 +1,24 @@
+import HttpClient from "~/lib/http_client";
+import { UrlBuilder } from "~/lib/url_builder";
+
+export type ConfigResponse = {
+  key: string;
+  value: {
+    image: string;
+  };
+};
+
+export const getConfigByKey = async (
+  key: string,
+): Promise<ConfigResponse | null> => {
+  try {
+    const url = new UrlBuilder({ path: 'CONFIG_V1_GET' })
+      .param('configKey', key)
+      .build();
+    const response = await new HttpClient(url).get<{ data: ConfigResponse }>('');
+    return response.data;
+  } catch (error) {
+    console.error('Error fetching config:', error);
+    return null;
+  }
+};


### PR DESCRIPTION
## Summary
- add endpoint constant for config API
- fetch banner config on homepage and pass the image to the hero section
- update hero component to accept dynamic image
- add simple service for config API calls

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run typecheck` *(fails: Cannot find type definition file for '@remix-run/node')*

------
https://chatgpt.com/codex/tasks/task_e_684048faacd48326a90bf0fcbb48ad58