### PR TITLE
Implement temporary and persistent address saving

### DIFF
--- a/app/components/features/checkout/address-form.tsx
+++ b/app/components/features/checkout/address-form.tsx
@@ -23,7 +23,7 @@ export type Address = {
 
 interface AddressFormProps {
   existingAddress?: Address
-  onSave: (address: Address) => void
+  onSave: (address: Address) => void | Promise<void>
   onCancel?: () => void
 }
 
@@ -45,6 +45,7 @@ export default function AddressForm({ existingAddress, onSave, onCancel }: Addre
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
+    e.stopPropagation()
 
     // Validate required fields
     const requiredFields = ["firstName", "lastName", "address", "city", "state", "postalCode", "country", "phone"]
@@ -61,7 +62,7 @@ export default function AddressForm({ existingAddress, onSave, onCancel }: Addre
       id: existingAddress?.id || `address_${Date.now()}`,
     } as Address
 
-    onSave(completeAddress)
+    void onSave(completeAddress)
   }
 
   return (

--- a/app/configs/api_endpoint.ts
+++ b/app/configs/api_endpoint.ts
@@ -6,6 +6,9 @@ export const API_ENDPOINT = {
   COMPOSE_V1_HOME: '/api/v1/compose/home',
 
   // Config Endpoint
-  CONFIG_V1_GET: '/api/v1/configs/:configKey'
+  CONFIG_V1_GET: '/api/v1/configs/:configKey',
+
+  // Address Endpoint
+  ADDRESS_V1_CREATE: '/api/v1/addresses'
 
 } as const

--- a/app/routes/checkout._index.tsx
+++ b/app/routes/checkout._index.tsx
@@ -10,6 +10,7 @@ import { RadioGroup, RadioGroupItem } from "~/components/ui/radio-group"
 import { Separator } from "~/components/ui/separator"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "~/components/ui/tabs"
 import AddressForm, { type Address } from "~/components/features/checkout/address-form"
+import { createAddress } from "~/services/addresses"
 import ThaiQRPayment from "~/components/features/checkout/thai-qr-payment"
 import { useCart } from "~/context/cart-context"
 import { useAuth } from "~/context/auth-context"
@@ -34,7 +35,7 @@ type Order = {
 
 export default function CheckoutPage() {
   const { items, subtotal, clearCart } = useCart()
-  // const { isLoggedIn } = useAuth()
+  const { isLoggedIn } = useAuth()
 
   const [paymentMethod, setPaymentMethod] = useState<string>("thai_qr")
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -85,7 +86,7 @@ export default function CheckoutPage() {
     }
   }, [])
 
-  const saveAddress = (address: Address) => {
+  const saveAddress = async (address: Address) => {
     // If this is set as default, unset any other default
     let updatedAddresses = [...addresses]
 
@@ -108,8 +109,15 @@ export default function CheckoutPage() {
     setSelectedAddressId(address.id)
     setShowAddressForm(false)
 
-    // Save to localStorage
-    if (typeof window !== "undefined") {
+    if (isLoggedIn) {
+      try {
+        await createAddress(address)
+      } catch (error) {
+        console.error("Failed to save address via API:", error)
+        toast("Failed to save address. Please try again.")
+        return
+      }
+    } else if (typeof window !== "undefined") {
       localStorage.setItem("addresses", JSON.stringify(updatedAddresses))
     }
 

--- a/app/services/addresses.ts
+++ b/app/services/addresses.ts
@@ -1,0 +1,14 @@
+import HttpClient from "~/lib/http_client";
+import { UrlBuilder } from "~/lib/url_builder";
+import type { Address } from "~/components/features/checkout/address-form";
+
+export const createAddress = async (address: Address) => {
+  try {
+    const url = new UrlBuilder({ path: 'ADDRESS_V1_CREATE' }).build();
+    const response = await new HttpClient(url).post<{ data: Address }>('' , address);
+    return response.data;
+  } catch (error) {
+    console.error('Error creating address:', error);
+    throw error;
+  }
+};


### PR DESCRIPTION
## Summary
- add new API endpoint for address creation
- expose an `addresses` service for saving addresses via API
- store addresses for anonymous users in localStorage
- stop nested form submission propagation

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run typecheck` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_68406ff214708326ad70e282ab8afd4e