### PR TITLE
Fix editing existing addresses

### DIFF
--- a/app/components/features/checkout/address-form.tsx
+++ b/app/components/features/checkout/address-form.tsx
@@ -1,6 +1,6 @@
 import type React from "react"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { Button } from "~/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card"
 import { Input } from "~/components/ui/input"
@@ -33,6 +33,12 @@ export default function AddressForm({ existingAddress, onSave, onCancel }: Addre
       isDefault: true,
     },
   )
+
+  useEffect(() => {
+    if (existingAddress) {
+      setAddress(existingAddress)
+    }
+  }, [existingAddress])
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target

--- a/app/routes/checkout._index.tsx
+++ b/app/routes/checkout._index.tsx
@@ -54,6 +54,7 @@ export default function CheckoutPage() {
   const [addresses, setAddresses] = useState<Address[]>([])
   const [selectedAddressId, setSelectedAddressId] = useState<string | null>(null)
   const [showAddressForm, setShowAddressForm] = useState(false)
+  const [editingAddress, setEditingAddress] = useState<Address | null>(null)
 
   const shipping = subtotal >= 50 ? 0 : 5.99
   const total = subtotal + shipping
@@ -108,6 +109,7 @@ export default function CheckoutPage() {
     setAddresses(updatedAddresses)
     setSelectedAddressId(address.id)
     setShowAddressForm(false)
+    setEditingAddress(null)
 
     if (isLoggedIn) {
       try {
@@ -284,7 +286,14 @@ export default function CheckoutPage() {
                   <CardTitle>Shipping Address</CardTitle>
                   <CardDescription>
                     {addresses.length > 0 && !showAddressForm ? (
-                      <Button variant="link" className="p-0 h-auto" onClick={() => setShowAddressForm(true)}>
+                      <Button
+                        variant="link"
+                        className="p-0 h-auto"
+                        onClick={() => {
+                          setEditingAddress(null)
+                          setShowAddressForm(true)
+                        }}
+                      >
                         + Add new address
                       </Button>
                     ) : null}
@@ -293,8 +302,12 @@ export default function CheckoutPage() {
                 <CardContent>
                   {showAddressForm ? (
                     <AddressForm
+                      existingAddress={editingAddress ?? undefined}
                       onSave={saveAddress}
-                      onCancel={addresses.length > 0 ? () => setShowAddressForm(false) : undefined}
+                      onCancel={addresses.length > 0 ? () => {
+                        setShowAddressForm(false)
+                        setEditingAddress(null)
+                      } : undefined}
                     />
                   ) : addresses.length > 0 ? (
                     <RadioGroup
@@ -324,11 +337,10 @@ export default function CheckoutPage() {
                                 className="h-auto py-0 px-2"
                                 onClick={(e) => {
                                   e.preventDefault()
-                                  setShowAddressForm(true)
-                                  // Find the address and set it for editing
                                   const addrToEdit = addresses.find((a) => a.id === address.id)
                                   if (addrToEdit) {
-                                    // This would set the address for editing
+                                    setEditingAddress(addrToEdit)
+                                    setShowAddressForm(true)
                                   }
                                 }}
                               >


### PR DESCRIPTION
## Summary
- allow selecting an address to edit in checkout
- update AddressForm when editing existing addresses

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*
- `npm run typecheck` *(fails: Cannot find type definition file for '@remix-run/node')*

------
https://chatgpt.com/codex/tasks/task_e_6840934209948326835790c64fdf2980